### PR TITLE
pem.Block.Type ==  requirement removed

### DIFF
--- a/signatures.go
+++ b/signatures.go
@@ -192,7 +192,7 @@ func SignGkms(message string, privateKeyName string) (string, error) {
 func VerifySignatureGkms(message string, signatureHex string, publicKeyPem string) error {
 	// Parse the key
 	block, _ := pem.Decode([]byte(publicKeyPem))
-	if block == nil || block.Type != "PUBLIC KEY" {
+	if block == nil {
 		return errors.New("VerifySignatureGkms failed decode PEM block containing public key")
 	}
 	publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)


### PR DESCRIPTION
The PEM formatted RSA public keys derived from GCP KMS private keys do not get the Type property set to 'PUBLIC KEY' when converted to *rsa.PublicKey. This led to a redundant check failing otherwise working code. Given that there is a *rsa.PublicKey type assertion already, the `Type == "PUBLIC KEY"` check was removed as incompatible and redundant.